### PR TITLE
switch from positional to named argparse argument

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     
     if args.filename is not None:
         file_content = ''
-        with open(sys.argv[1]) as f:
+        with open(args.filename) as f:
             file_content = f.read()
 
         print(generateTemplate(file_content, []))


### PR DESCRIPTION
```sh
Traceback (most recent call last):
  File "convert.py", line 91, in <module>
    with open(sys.argv[1]) as f:
FileNotFoundError: [Errno 2] No such file or directory: '--filename'
```